### PR TITLE
Interpret memory and disk storage as mebibytes

### DIFF
--- a/k8s/stset/lrp_to_statefulset.go
+++ b/k8s/stset/lrp_to_statefulset.go
@@ -246,9 +246,9 @@ func getVolumeSpecs(lrpVolumeMounts []eiriniv1.VolumeMount) ([]corev1.Volume, []
 }
 
 func getContainerResources(cpuWeight uint8, memoryMB, diskMB int64) corev1.ResourceRequirements {
-	memory := NewMebibyteQuantity(memoryMB)
+	memory := MebibyteQuantity(memoryMB)
 	cpu := toCPUMillicores(cpuWeight)
-	ephemeralStorage := NewMebibyteQuantity(diskMB)
+	ephemeralStorage := MebibyteQuantity(diskMB)
 	return corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceMemory:           memory,
@@ -261,11 +261,11 @@ func getContainerResources(cpuWeight uint8, memoryMB, diskMB int64) corev1.Resou
 	}
 }
 
-func NewMebibyteQuantity(miB int64) resource.Quantity {
+func MebibyteQuantity(miB int64) resource.Quantity {
 	memory := resource.Quantity{
 		Format: resource.BinarySI,
 	}
-	memory.SetScaled(miB*1024*1024, 0)
+	memory.Set(miB * 1024 * 1024)
 	return memory
 }
 

--- a/k8s/stset/lrp_to_statefulset.go
+++ b/k8s/stset/lrp_to_statefulset.go
@@ -246,10 +246,9 @@ func getVolumeSpecs(lrpVolumeMounts []eiriniv1.VolumeMount) ([]corev1.Volume, []
 }
 
 func getContainerResources(cpuWeight uint8, memoryMB, diskMB int64) corev1.ResourceRequirements {
-	memory := *resource.NewScaledQuantity(memoryMB, resource.Mega)
+	memory := NewMebibyteQuantity(memoryMB)
 	cpu := toCPUMillicores(cpuWeight)
-	ephemeralStorage := *resource.NewScaledQuantity(diskMB, resource.Mega)
-
+	ephemeralStorage := NewMebibyteQuantity(diskMB)
 	return corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceMemory:           memory,
@@ -260,6 +259,14 @@ func getContainerResources(cpuWeight uint8, memoryMB, diskMB int64) corev1.Resou
 			corev1.ResourceCPU:    cpu,
 		},
 	}
+}
+
+func NewMebibyteQuantity(miB int64) resource.Quantity {
+	memory := resource.Quantity{
+		Format: resource.BinarySI,
+	}
+	memory.SetScaled(miB*1024*1024, 0)
+	return memory
 }
 
 func toCPUMillicores(cpuPercentage uint8) resource.Quantity {

--- a/k8s/stset/lrp_to_statefulset_test.go
+++ b/k8s/stset/lrp_to_statefulset_test.go
@@ -171,15 +171,13 @@ var _ = Describe("LRP to StatefulSet Converter", func() {
 	})
 
 	It("should set memory limit", func() {
-		expectedLimit := resource.NewScaledQuantity(1024, resource.Mega)
 		actualLimit := statefulSet.Spec.Template.Spec.Containers[0].Resources.Limits.Memory()
-		Expect(actualLimit).To(Equal(expectedLimit))
+		Expect(actualLimit.String()).To(Equal("1Gi"))
 	})
 
 	It("should set memory request", func() {
-		expectedLimit := resource.NewScaledQuantity(1024, resource.Mega)
 		actualLimit := statefulSet.Spec.Template.Spec.Containers[0].Resources.Requests.Memory()
-		Expect(actualLimit).To(Equal(expectedLimit))
+		Expect(actualLimit.String()).To(Equal("1Gi"))
 	})
 
 	It("should set cpu request", func() {
@@ -189,9 +187,8 @@ var _ = Describe("LRP to StatefulSet Converter", func() {
 	})
 
 	It("should set disk limit", func() {
-		expectedLimit := resource.NewScaledQuantity(2048, resource.Mega)
 		actualLimit := statefulSet.Spec.Template.Spec.Containers[0].Resources.Limits.StorageEphemeral()
-		Expect(actualLimit).To(Equal(expectedLimit))
+		Expect(actualLimit.String()).To(Equal("2Gi"))
 	})
 
 	It("should set user defined annotations", func() {
@@ -313,11 +310,11 @@ var _ = Describe("LRP to StatefulSet Converter", func() {
 					Env:     []corev1.EnvVar{{Name: "FOO", Value: "BAR"}},
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							corev1.ResourceMemory:           *resource.NewScaledQuantity(101, resource.Mega),
-							corev1.ResourceEphemeralStorage: *resource.NewScaledQuantity(lrp.Spec.DiskMB, resource.Mega),
+							corev1.ResourceMemory:           stset.NewMebibyteQuantity(101),
+							corev1.ResourceEphemeralStorage: stset.NewMebibyteQuantity(lrp.Spec.DiskMB),
 						},
 						Requests: corev1.ResourceList{
-							corev1.ResourceMemory: *resource.NewScaledQuantity(101, resource.Mega),
+							corev1.ResourceMemory: stset.NewMebibyteQuantity(101),
 							corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(lrp.Spec.CPUWeight), resource.Milli),
 						},
 					},
@@ -329,11 +326,11 @@ var _ = Describe("LRP to StatefulSet Converter", func() {
 					Env:     []corev1.EnvVar{{Name: "FOO", Value: "BAZ"}},
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							corev1.ResourceMemory:           *resource.NewScaledQuantity(102, resource.Mega),
-							corev1.ResourceEphemeralStorage: *resource.NewScaledQuantity(lrp.Spec.DiskMB, resource.Mega),
+							corev1.ResourceMemory:           stset.NewMebibyteQuantity(102),
+							corev1.ResourceEphemeralStorage: stset.NewMebibyteQuantity(lrp.Spec.DiskMB),
 						},
 						Requests: corev1.ResourceList{
-							corev1.ResourceMemory: *resource.NewScaledQuantity(102, resource.Mega),
+							corev1.ResourceMemory: stset.NewMebibyteQuantity(102),
 							corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(lrp.Spec.CPUWeight), resource.Milli),
 						},
 					},

--- a/k8s/stset/lrp_to_statefulset_test.go
+++ b/k8s/stset/lrp_to_statefulset_test.go
@@ -310,11 +310,11 @@ var _ = Describe("LRP to StatefulSet Converter", func() {
 					Env:     []corev1.EnvVar{{Name: "FOO", Value: "BAR"}},
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							corev1.ResourceMemory:           stset.NewMebibyteQuantity(101),
-							corev1.ResourceEphemeralStorage: stset.NewMebibyteQuantity(lrp.Spec.DiskMB),
+							corev1.ResourceMemory:           stset.MebibyteQuantity(101),
+							corev1.ResourceEphemeralStorage: stset.MebibyteQuantity(lrp.Spec.DiskMB),
 						},
 						Requests: corev1.ResourceList{
-							corev1.ResourceMemory: stset.NewMebibyteQuantity(101),
+							corev1.ResourceMemory: stset.MebibyteQuantity(101),
 							corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(lrp.Spec.CPUWeight), resource.Milli),
 						},
 					},
@@ -326,11 +326,11 @@ var _ = Describe("LRP to StatefulSet Converter", func() {
 					Env:     []corev1.EnvVar{{Name: "FOO", Value: "BAZ"}},
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							corev1.ResourceMemory:           stset.NewMebibyteQuantity(102),
-							corev1.ResourceEphemeralStorage: stset.NewMebibyteQuantity(lrp.Spec.DiskMB),
+							corev1.ResourceMemory:           stset.MebibyteQuantity(102),
+							corev1.ResourceEphemeralStorage: stset.MebibyteQuantity(lrp.Spec.DiskMB),
 						},
 						Requests: corev1.ResourceList{
-							corev1.ResourceMemory: stset.NewMebibyteQuantity(102),
+							corev1.ResourceMemory: stset.MebibyteQuantity(102),
 							corev1.ResourceCPU:    *resource.NewScaledQuantity(int64(lrp.Spec.CPUWeight), resource.Milli),
 						},
 					},

--- a/tests/integration/k8s/stset/desire_test.go
+++ b/tests/integration/k8s/stset/desire_test.go
@@ -266,13 +266,12 @@ var _ = Describe("Desire", func() {
 					limits := container.Resources.Limits
 					requests := container.Resources.Requests
 
-					expectedMemory := resource.NewScaledQuantity(101, resource.Mega)
-					expectedDisk := resource.NewScaledQuantity(lrp.Spec.DiskMB, resource.Mega)
+					expectedDisk := stset.MebibyteQuantity(lrp.Spec.DiskMB)
 					expectedCPU := resource.NewScaledQuantity(int64(lrp.Spec.CPUWeight*10), resource.Milli)
 
-					assertEqualValues(limits.Memory(), expectedMemory)
-					assertEqualValues(limits.StorageEphemeral(), expectedDisk)
-					assertEqualValues(requests.Memory(), expectedMemory)
+					Expect(limits.Memory().String()).To(Equal("101Mi"))
+					Expect(limits.StorageEphemeral().String()).To(Equal(expectedDisk.String()))
+					Expect(requests.Memory().String()).To(Equal("101Mi"))
 					assertEqualValues(requests.Cpu(), expectedCPU)
 				}
 			}


### PR DESCRIPTION
 - In CloudFoundry, the memory and disk values are [interpreted as
   mebibytes](https://github.com/cloudfoundry/bytefmt/blob/master/bytes.go#L80-L87) so this brings eirini-controller in sync with that
 - This change was made due to [this Issue](https://github.com/cloudfoundry/korifi/issues/720)

@gcapizzi @julian-hj
